### PR TITLE
Changed error handling in AccountKey authorization

### DIFF
--- a/src/HooksRouter.js
+++ b/src/HooksRouter.js
@@ -1,31 +1,32 @@
 import { HooksRouter as _HooksRouter } from 'parse-server/lib/Routers/HooksRouter';
-import * as middlewares from "parse-server/lib/middlewares";
+import * as middlewares from 'parse-server/lib/middlewares';
 const express = require('express');
 
 export default class HooksRouter extends _HooksRouter {
 
-    handleGetFunctions(req) {
-        return super.handleGetFunctions(req)
-        .then(this._patchResponse);
-    }
+  handleGetFunctions(req) {
+    return super.handleGetFunctions(req)
+      .then(this._patchResponse);
+  }
 
-    handleGetTriggers(req) {
-        return super.handleGetTriggers(req)
-        .then(this._patchResponse);
-    }
+  handleGetTriggers(req) {
+    return super.handleGetTriggers(req)
+      .then(this._patchResponse);
+  }
 
-    _patchResponse(response) {
-        return {
-            response: {
-                results: response.response,
-            }
-        };
-    }
+  _patchResponse(response) {
+    console.log(response);
+    return {
+      response: {
+        results: response.response,
+      }
+    };
+  }
 
-    mountOnto(app) {
-        var hooksApp = express();
-        hooksApp.use('/hooks', middlewares.handleParseHeaders);
-        super.mountOnto(hooksApp);
-        return app.use('/1', hooksApp);
-    }
+  mountOnto(app) {
+    var hooksApp = express();
+    hooksApp.use('/hooks', middlewares.handleParseHeaders);
+    super.mountOnto(hooksApp);
+    return app.use('/1', hooksApp);
+  }
 }

--- a/src/ParseCliRouter.js
+++ b/src/ParseCliRouter.js
@@ -55,8 +55,12 @@ class ParseCliRouter extends PromiseRouter {
       req.config.accountKey = accountKey;
     }).catch(error => {
       let errorObj = new Error();
-      errorObj.status = 400;
-      errorObj.message = error;
+      if (error === 'invalid email and password') {
+        errorObj.status = 401;
+      } else {
+        errorObj.status = 400;
+      }
+        errorObj.message = error;
       throw errorObj;
     });
   }


### PR DESCRIPTION
The `parse-cli` expect a response with 401 status when the user fail to login.
Now the program print the correct error message.